### PR TITLE
DOC: math mode x to \times in docstring for numpy.linalg.multi_dot

### DIFF
--- a/numpy/linalg/_linalg.py
+++ b/numpy/linalg/_linalg.py
@@ -2903,7 +2903,7 @@ def multi_dot(arrays, *, out=None):
             return A.shape[0] * A.shape[1] * B.shape[1]
 
     Assume we have three matrices
-    :math:`A_{10x100}, B_{100x5}, C_{5x50}`.
+    :math:`A_{10 \times 100}, B_{100 \times 5}, C_{5 \times 50}`.
 
     The costs for the two different parenthesizations are as follows::
 


### PR DESCRIPTION
This is a small tweak to the documentation for [`numpy.linalg.multi_dot`](https://numpy.org/doc/2.2/reference/generated/numpy.linalg.multi_dot.html) to replace $x$ with $\times$ in the dimensions of the example matrices. Specifically, this changes the appearance of the LaTeX matrices from

$$A_{10x100}, B_{100x5}, C_{5x50}$$

to

$$A_{10 \times 100}, B_{100 \times 5}, C_{5 \times 50}$$
